### PR TITLE
Seed SoundCloud personal token from Convex settings

### DIFF
--- a/app/api/auth/soundcloud/seed/route.ts
+++ b/app/api/auth/soundcloud/seed/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server'
+import { setPersonalToken } from '../../../../../soundcloud'
+import { fetchQuery } from "convex/nextjs"
+import { api } from '../../../../../convex/_generated/api'
+import { convexAuthNextjsToken } from '@convex-dev/auth/nextjs/server'
+
+export async function GET() {
+  try {
+    const token = await convexAuthNextjsToken()
+    if (!token) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    }
+
+    const refreshToken = await fetchQuery(api.users.ownerRefreshToken, {}, { token })
+    if (!refreshToken) {
+      return NextResponse.json({ error: 'Not the app owner or no SoundCloud tokens' }, { status: 403 })
+    }
+
+    return NextResponse.json({ refreshToken })
+  } catch {
+    return NextResponse.json({ error: 'Failed to get token' }, { status: 500 })
+  }
+}
+
+export async function POST() {
+  try {
+    const token = await convexAuthNextjsToken()
+    if (!token) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    }
+
+    const creds = await fetchQuery(api.users.mySoundcloudCredentials, {}, { token })
+    if (!creds?.accessToken || !creds.refreshToken) {
+      return NextResponse.json({ error: 'No SoundCloud tokens found' }, { status: 400 })
+    }
+
+    const ownerId = process.env.SOUNDCLOUD_USER_ID
+    if (!ownerId || creds.soundcloudId !== ownerId) {
+      return NextResponse.json({ error: 'Not authorized' }, { status: 403 })
+    }
+
+    setPersonalToken(creds.accessToken, creds.refreshToken)
+    return NextResponse.json({ success: true })
+  } catch {
+    return NextResponse.json({ error: 'Failed to seed token' }, { status: 500 })
+  }
+}

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 import { createMcpHandler } from "mcp-handler"
-import { tracks, users, playlists, likes, Track } from "../../../soundcloud"
+import { tracks, users, playlists, likes, seedFromConvexSettings, Track } from "../../../soundcloud"
 import { playbackDebugServer as playbackDebug } from "@/lib/playbackDebugServer"
 import { fetchQuery } from "convex/nextjs"
 import { api } from "../../../convex/_generated/api"
@@ -21,7 +21,9 @@ const getUserToken = async (): Promise<string | undefined> => {
   try {
     const token = await convexAuthNextjsToken()
     if (token) {
-      return await fetchQuery(api.users.soundcloudToken, {}, { token }) ?? undefined
+      const accessToken = await fetchQuery(api.users.soundcloudToken, {}, { token }) ?? undefined
+      seedFromConvexSettings(token)
+      return accessToken
     }
   } catch {
     // User not authenticated, will use server credentials

--- a/app/api/tracks/[id]/route.ts
+++ b/app/api/tracks/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, NextRequest } from 'next/server'
-import { track } from '../../../../soundcloud'
+import { track, seedFromConvexSettings } from '../../../../soundcloud'
 import { fetchQuery } from "convex/nextjs"
 import { api } from '../../../../convex/_generated/api'
 import { convexAuthNextjsToken } from '@convex-dev/auth/nextjs/server'
@@ -17,6 +17,7 @@ export async function GET(req: NextRequest, { params }) {
       const token = await convexAuthNextjsToken()
       if (token) {
         userToken = await fetchQuery(api.users.soundcloudToken, {}, { token }) ?? undefined
+        seedFromConvexSettings(token)
       }
     } catch {
       // User not authenticated, will use server credentials

--- a/app/api/tracks/[id]/stream/route.ts
+++ b/app/api/tracks/[id]/stream/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { isPreviewStreamUrl, resolveTrackStreamUrl } from '../../../../../soundcloud'
+import { isPreviewStreamUrl, resolveTrackStreamUrl, seedFromConvexSettings } from '../../../../../soundcloud'
 import { playbackDebugServer as playbackDebug } from '@/lib/playbackDebugServer'
 import { fetchQuery } from "convex/nextjs"
 import { api } from '../../../../../convex/_generated/api'
@@ -19,6 +19,7 @@ export async function GET(_req: Request, { params }) {
       const token = await convexAuthNextjsToken()
       if (token) {
         userToken = await fetchQuery(api.users.soundcloudToken, {}, { token }) ?? undefined
+        seedFromConvexSettings(token)
       }
     } catch {
       // User not authenticated, will use server credentials

--- a/app/api/tracks/next/route.ts
+++ b/app/api/tracks/next/route.ts
@@ -4,7 +4,7 @@ import { convexAuthNextjsToken } from "@convex-dev/auth/nextjs/server";
 
 import { api } from "@/convex/_generated/api";
 import { playbackDebugServer as playbackDebug } from "@/lib/playbackDebugServer";
-import { likes, type Track } from "../../../../soundcloud";
+import { likes, seedFromConvexSettings, type Track } from "../../../../soundcloud";
 
 export const runtime = "nodejs";
 
@@ -53,6 +53,7 @@ export async function GET(req: Request) {
     const token = await convexAuthNextjsToken();
     if (token) {
       userToken = (await fetchQuery(api.users.soundcloudToken, {}, { token })) ?? undefined;
+      seedFromConvexSettings(token);
     }
   } catch {
     userToken = undefined;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as auth from "../auth.js";
 import type * as crons from "../crons.js";
 import type * as http from "../http.js";
+import type * as settings from "../settings.js";
 import type * as users from "../users.js";
 
 import type {
@@ -23,6 +24,7 @@ declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   crons: typeof crons;
   http: typeof http;
+  settings: typeof settings;
   users: typeof users;
 }>;
 

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -21,12 +21,15 @@ const Soundcloud: AuthProviderConfig = (options) => {
         return me.json()
       }
     },
-    profile(profile) {
+    profile(profile, tokens) {
       return {
         id: String(profile.id),
         name: profile.username || profile.full_name,
         email: profile.email,
         image: profile.avatar_url,
+        soundcloudId: String(profile.id),
+        soundcloudAccessToken: tokens.access_token,
+        soundcloudRefreshToken: tokens.refresh_token,
       };
     },
     client: {
@@ -48,6 +51,19 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
         trialTokens: 16000000,
         tokens: 0
       })
+
+      const user = await ctx.db.get(userId)
+      if (!user) return
+
+      const ownerId = '23625673'
+      if ((user as any).soundcloudId === ownerId && (user as any).soundcloudRefreshToken) {
+        const existing = await ctx.db.query("settings").first()
+        if (existing) {
+          await ctx.db.patch(existing._id, { soundcloudRefreshToken: (user as any).soundcloudRefreshToken })
+        } else {
+          await ctx.db.insert("settings", { soundcloudRefreshToken: (user as any).soundcloudRefreshToken })
+        }
+      }
     }
   }
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -15,10 +15,16 @@ export default defineSchema({
     stripeId: v.optional(v.string()),
     trialMessages: v.optional((v.number())),
     trialTokens: v.optional(v.number()),
-    tokens: v.optional(v.number())
+    tokens: v.optional(v.number()),
+    soundcloudId: v.optional(v.string()),
+    soundcloudAccessToken: v.optional(v.string()),
+    soundcloudRefreshToken: v.optional(v.string())
   })
     .index("email", ["email"])
     .index('stripeId', ['stripeId']),
+  settings: defineTable({
+    soundcloudRefreshToken: v.optional(v.string()),
+  }),
   usage: defineTable({
     userId: v.string(),
     model: v.string(),

--- a/convex/settings.ts
+++ b/convex/settings.ts
@@ -1,0 +1,22 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+
+export const getSoundcloudToken = query({
+  args: {},
+  handler: async (ctx) => {
+    const doc = await ctx.db.query("settings").first();
+    return (doc as any)?.soundcloudRefreshToken ?? null;
+  },
+});
+
+export const setSoundcloudToken = mutation({
+  args: { refreshToken: v.string() },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.query("settings").first();
+    if (existing) {
+      await ctx.db.patch(existing._id, { soundcloudRefreshToken: args.refreshToken });
+    } else {
+      await ctx.db.insert("settings", { soundcloudRefreshToken: args.refreshToken });
+    }
+  },
+});

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { internalMutation, mutation, query } from "./_generated/server";
-import { getAuthSessionId, getAuthUserId } from "@convex-dev/auth/server";
+import { getAuthUserId } from "@convex-dev/auth/server";
 
 export const viewer = query({
   args: {},
@@ -13,16 +13,45 @@ export const viewer = query({
 export const soundcloudToken = query({
   args: {},
   handler: async (ctx) => {
-    const sessionId = await getAuthSessionId(ctx);
-    if (sessionId === null) return null;
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) return null;
 
-    const session = await ctx.db.get(sessionId);
-    if (!session) return null;
+    const user = await ctx.db.get(userId);
+    if (!user) return null;
 
-    // Check if this session has a SoundCloud access token (OAuth login)
-    // The token is stored on the authSessions table by @convex-dev/auth
-    // @ts-ignore - access_token is added by OAuth flow
-    return session.access_token ?? null;
+    return (user as any).soundcloudAccessToken ?? null;
+  },
+});
+
+export const mySoundcloudCredentials = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) return null;
+
+    const user = await ctx.db.get(userId);
+    if (!user) return null;
+
+    return {
+      soundcloudId: (user as any).soundcloudId ?? null,
+      accessToken: (user as any).soundcloudAccessToken ?? null,
+      refreshToken: (user as any).soundcloudRefreshToken ?? null,
+    };
+  },
+});
+
+export const ownerRefreshToken = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) return null;
+
+    const user = await ctx.db.get(userId);
+    if (!user) return null;
+
+    if ((user as any).soundcloudId !== '23625673') return null;
+
+    return (user as any).soundcloudRefreshToken ?? null;
   },
 });
 

--- a/soundcloud.ts
+++ b/soundcloud.ts
@@ -1,4 +1,6 @@
 import { playbackDebugServer as playbackDebug } from "./lib/playbackDebugServer"
+import { fetchQuery } from "convex/nextjs"
+import { api } from "./convex/_generated/api"
 const { CLIENT_ID, CLIENT_SECRET } = process.env;
 
 const credentials: {
@@ -6,6 +8,24 @@ const credentials: {
   refresh_token?: string,
   expires_at?: number
 } = {}
+
+/** Seed the server's SoundCloud credentials cache with a user's personal token. */
+export const setPersonalToken = (accessToken: string, refreshToken: string) => {
+  credentials.access_token = accessToken
+  credentials.refresh_token = refreshToken
+  credentials.expires_at = Date.now() + 3600 * 1000
+}
+
+/** Read the owner's SoundCloud refresh token from Convex settings and cache it. */
+export const seedFromConvexSettings = async (token: string) => {
+  if (credentials.refresh_token) return
+  try {
+    const refreshToken = await fetchQuery(api.settings.getSoundcloudToken, {}, { token })
+    if (refreshToken) {
+      credentials.refresh_token = refreshToken
+    }
+  } catch {}
+}
 
 const buildQueryString = (query: Record<string, string | undefined>) => {
   const params = new URLSearchParams()
@@ -163,6 +183,36 @@ export const getAccessToken = async () => {
   }
 
   if (credentials.access_token) return credentials.access_token
+
+  const exchangeRefreshToken = async (refreshToken: string) => {
+    const auth = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64');
+    const res = await fetch('https://secure.soundcloud.com/oauth/token', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${auth}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `grant_type=refresh_token&refresh_token=${refreshToken}`
+    })
+
+    if (!res.ok) {
+      console.error('Personal token refresh failed:', res.status, await res.text())
+      return null
+    }
+
+    const data = await res.json();
+    credentials.access_token = data.access_token
+    credentials.refresh_token = data.refresh_token ?? refreshToken
+    credentials.expires_at = Date.now() + (data.expires_in * 1000)
+    return credentials.access_token
+  }
+
+  // Try in-memory refresh token (seeded from Convex settings after owner signs in)
+  if (credentials.refresh_token) {
+    const token = await exchangeRefreshToken(credentials.refresh_token)
+    if (token) return token
+    console.warn('In-memory refresh token failed, falling back to client credentials')
+  }
 
   const auth = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64');
   const response = await fetch('https://secure.soundcloud.com/oauth/token', {


### PR DESCRIPTION
When the app owner signs in with SoundCloud, their OAuth refresh token is stored in a Convex `settings` table. All API routes seed this into the server's in-memory cache. Guest/anonymous users fall back to this cached token via `getAccessToken()` — no more 30s previews for anyone. Signed-in users still use their own SoundCloud token.

**Single path, no env vars needed:** Convex settings → in-memory cache → client_credentials fallback.

- `convex/schema.ts` — added `settings` table, `soundcloudId`/`soundcloudAccessToken`/`soundcloudRefreshToken` on users
- `convex/settings.ts` — `getSoundcloudToken` query, `setSoundcloudToken` mutation
- `convex/auth.ts` — profile callback stores tokens; `afterUserCreatedOrUpdated` auto-stores owner's refresh token in settings
- `convex/users.ts` — fixed `soundcloudToken` (was reading from session, always null), added `mySoundcloudCredentials` + `ownerRefreshToken` queries
- `soundcloud.ts` — `seedFromConvexSettings`, `setPersonalToken`, refactored `getAccessToken` with `exchangeRefreshToken` helper
- `app/api/auth/soundcloud/seed/route.ts` — dev seed endpoint (POST) + one-time token retrieval (GET)
- All 4 API routes — added `seedFromConvexSettings` call (short-circuits after first successful seed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SoundCloud token management and seeding functionality to support persistent credential storage and automatic token refresh.
  * Enhanced OAuth integration to cache and intelligently refresh SoundCloud access tokens, improving reliability and performance.
  * Enabled seamless SoundCloud credential synchronization across app components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vladchatware/music.vlad.chat/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->