### PR TITLE
Fall back to Convex settings token for guest SoundCloud access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ soundcloud.json
 .vercel
 
 coverage/
+tsconfig.tsbuildinfo

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as auth from "../auth.js";
 import type * as crons from "../crons.js";
 import type * as http from "../http.js";
+import type * as settings from "../settings.js";
 import type * as users from "../users.js";
 
 import type {
@@ -23,6 +24,7 @@ declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   crons: typeof crons;
   http: typeof http;
+  settings: typeof settings;
   users: typeof users;
 }>;
 

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -21,12 +21,15 @@ const Soundcloud: AuthProviderConfig = (options) => {
         return me.json()
       }
     },
-    profile(profile) {
+    profile(profile, tokens) {
       return {
         id: String(profile.id),
         name: profile.username || profile.full_name,
         email: profile.email,
         image: profile.avatar_url,
+        soundcloudId: String(profile.id),
+        soundcloudAccessToken: tokens.access_token,
+        soundcloudRefreshToken: tokens.refresh_token,
       };
     },
     client: {
@@ -48,6 +51,21 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
         trialTokens: 16000000,
         tokens: 0
       })
+
+      const user = await ctx.db.get(userId)
+      if (!user) return
+
+      if ((user as any)?.soundcloudId !== process.env.SOUNDCLOUD_USER_ID) return
+
+      const refreshToken = (user as any)?.soundcloudRefreshToken
+      if (!refreshToken) return
+
+      const existing = await ctx.db.query("settings").first()
+      if (existing) {
+        await ctx.db.patch(existing._id, { refreshToken })
+      } else {
+        await ctx.db.insert("settings", { refreshToken })
+      }
     }
   }
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -15,10 +15,16 @@ export default defineSchema({
     stripeId: v.optional(v.string()),
     trialMessages: v.optional((v.number())),
     trialTokens: v.optional(v.number()),
-    tokens: v.optional(v.number())
+    tokens: v.optional(v.number()),
+    soundcloudId: v.optional(v.string()),
+    soundcloudAccessToken: v.optional(v.string()),
+    soundcloudRefreshToken: v.optional(v.string())
   })
     .index("email", ["email"])
     .index('stripeId', ['stripeId']),
+  settings: defineTable({
+    refreshToken: v.optional(v.string()),
+  }),
   usage: defineTable({
     userId: v.string(),
     model: v.string(),

--- a/convex/settings.ts
+++ b/convex/settings.ts
@@ -1,0 +1,22 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+
+export const getRefreshToken = query({
+  args: {},
+  handler: async (ctx) => {
+    const doc = await ctx.db.query("settings").first();
+    return (doc as any)?.refreshToken ?? null;
+  },
+});
+
+export const setRefreshToken = mutation({
+  args: { refreshToken: v.string() },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.query("settings").first();
+    if (existing) {
+      await ctx.db.patch(existing._id, { refreshToken: args.refreshToken });
+    } else {
+      await ctx.db.insert("settings", { refreshToken: args.refreshToken });
+    }
+  },
+});

--- a/soundcloud.ts
+++ b/soundcloud.ts
@@ -1,4 +1,6 @@
 import { playbackDebugServer as playbackDebug } from "./lib/playbackDebugServer"
+import { fetchQuery } from "convex/nextjs"
+import { api } from "./convex/_generated/api"
 const { CLIENT_ID, CLIENT_SECRET } = process.env;
 
 const credentials: {
@@ -148,8 +150,11 @@ const readAccessToken = async () => {
 
     if (credentials.refresh_token && Date.now() > credentials.expires_at) {
       console.log('token expired, refreshing')
-      return refreshToken(credentials.refresh_token)
+      const token = await refreshToken(credentials.refresh_token)
+      if (token) return token
     }
+
+    return getAccessToken()
 
   } catch (e) {
     console.log('error', e)
@@ -163,6 +168,18 @@ export const getAccessToken = async () => {
   }
 
   if (credentials.access_token) return credentials.access_token
+
+  if (!credentials.refresh_token) {
+    try {
+      const rt = await fetchQuery(api.settings.getRefreshToken, {})
+      if (rt) credentials.refresh_token = rt
+    } catch {}
+  }
+
+  if (credentials.refresh_token) {
+    const token = await refreshToken(credentials.refresh_token)
+    if (token) return token
+  }
 
   const auth = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64');
   const response = await fetch('https://secure.soundcloud.com/oauth/token', {
@@ -189,24 +206,22 @@ export const getAccessToken = async () => {
   return credentials.access_token
 }
 
-export const refreshToken = async (refresh_token) => {
+export const refreshToken = async (refresh_token: string) => {
   const auth = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64');
-  const response = await fetch('https://secure.soundcloud.com/oauth/token', {
+  const res = await fetch('https://secure.soundcloud.com/oauth/token', {
     method: 'POST',
     headers: {
       'Authorization': `Basic ${auth}`,
       'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: `grant_type=refresh_token&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${refresh_token}`
+    body: `grant_type=refresh_token&refresh_token=${refresh_token}`
   })
 
-  if (!response.ok) {
-    throw new Error(`Authentication failed with status: ${response.status}`);
-  }
-  const data = await response.json();
+  if (!res.ok) return null
 
+  const data = await res.json();
   credentials.access_token = data.access_token
-  credentials.refresh_token = data.refresh_token
+  credentials.refresh_token = data.refresh_token ?? refresh_token
   credentials.expires_at = Date.now() + (data.expires_in * 1000)
 
   return credentials.access_token


### PR DESCRIPTION
When the app owner signs in with SoundCloud, their OAuth refresh token is stored in a Convex `settings` table. `getAccessToken()` reads it before falling through to `client_credentials` (30s previews). Also fixes the `soundcloudToken` query which was reading from `authSessions` (always null) — now reads from the user doc where tokens are stored.

**Result:** Full tracks for everyone. Signed-in users see personalized track info from their own SoundCloud token via the fixed `soundcloudToken` query.

**Setup:** `npx convex env set SOUNDCLOUD_USER_ID 23625673` then sign in with SoundCloud once on the live site.

- `convex/schema.ts` — `settings` table + token fields on users
- `convex/settings.ts` — `getRefreshToken` + `setRefreshToken`
- `convex/auth.ts` — profile stores tokens, callback stores in settings
- `convex/users.ts` — fixed `soundcloudToken` to read from user doc
- `soundcloud.ts` — `getAccessToken` fetches refresh token from Convex settings
- `.gitignore` — untrack `tsconfig.tsbuildinfo`